### PR TITLE
Update ideas2.0

### DIFF
--- a/app/assets/javascripts/add.js
+++ b/app/assets/javascripts/add.js
@@ -1,4 +1,4 @@
-function inputSubmitListener(){
+function addIdeaListener(){
   $("#add-idea").on('click', function(){
     var title = $(".field input").val();
     var body  = $(".field textarea").val();
@@ -24,6 +24,7 @@ function addIdea(params){
     },
     error: function(xhr){
       console.log(xhr.responseText);
+      clearForm();
     }
   })
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,16 +12,17 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require semantic-ui
 //= require index
 //= require add
 //= require delete
+//= require update
 //= require_tree .
 
 
 $(document).ready(function(){
+  $('[contenteditable]').on('click', function(e){ alert(e)})
   fetchAllIdeas();
-  inputSubmitListener();
+  addIdeaListener();
   deleteIdeaListener();
 })

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,8 +21,8 @@
 
 
 $(document).ready(function(){
-  $('[contenteditable]').on('click', function(e){ alert(e)})
   fetchAllIdeas();
   addIdeaListener();
   deleteIdeaListener();
+  editIdeaListener();
 })

--- a/app/assets/javascripts/delete.js
+++ b/app/assets/javascripts/delete.js
@@ -1,6 +1,6 @@
 function deleteIdeaListener(){
   $("#recent-ideas").delegate('#delete-idea', 'click', function(){
-    var idea = this.closest('.item')
+    var idea = this.closest('.idea')
 
     $.ajax({
       type: 'DELETE',

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -29,7 +29,7 @@ function renderIdea(html){
 function buildHtml(idea){
   return "<div class='idea' data-id='"
           + idea.id
-          + "'><div class='content'><a class='header-description' contenteditable='true'>"
+          + "'><div class='content'><a id='idea' class='header-description' contenteditable='true'>"
           + idea.title
           + "</a>"
           + "<div contentEditable='true' class='body description'>"

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -27,17 +27,18 @@ function renderIdea(html){
 }
 
 function buildHtml(idea){
-  return "<div class='item' data-id='"
+  return "<div class='idea' data-id='"
           + idea.id
-          + "'><div class='content><a class='header'>"
+          + "'><div class='content'><a class='header-description' contenteditable='true'>"
           + idea.title
           + "</a>"
-          + "<div class='description'>"
+          + "<div contentEditable='true' class='body description'>"
           + idea.body.trunc(100, true)
           + "</div>"
           + "<div class='description'>"
           + idea.quality 
           + "</div>"
           + "</div>"
-          + "<button id='delete-idea'>Delete</button>";
+          + "<button id='delete-idea'>Delete</button>"
+          + "<button id='edit-idea'>Edit</button>"
 }

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -29,10 +29,10 @@ function renderIdea(html){
 function buildHtml(idea){
   return "<div class='idea' data-id='"
           + idea.id
-          + "'><div class='content'><a id='idea' class='header-description' contenteditable='true'>"
+          + "'><div class='content'><a id='ideaTitle' class='header-description' contenteditable='true'>"
           + idea.title
           + "</a>"
-          + "<div contentEditable='true' class='body description'>"
+          + "<div id='ideaBody' contentEditable='true' class='body description'>"
           + idea.body.trunc(100, true)
           + "</div>"
           + "<div class='description'>"

--- a/app/assets/javascripts/update.js
+++ b/app/assets/javascripts/update.js
@@ -1,34 +1,30 @@
 function editIdeaListener(){
-
-  $('#recent-ideas').delegate('.header-description', 'keyup', function(){
-    alert("fdsa")
-  });
+  editTitle();
 }
 
 function editTitle(){
-  $('.header-description').keydown(function(event){
-    debugger
-    if(event.keyCode == 13){
+  $('#recent-ideas').delegate('#idea', 'keydown', function(event){
+    if(event.which == 13 || event.keyCode == 13){
+      var $title = event.currentTarget.textContent
+      var $body  = $(this).siblings('.body.description')[0].innerHTML
+      var $id    = $(this).closest('.idea').attr('data-id')
+      var params = {
+        idea: {
+          title: $title,
+          body: $body
+        }
+      }
 
-
-      //var $title = event.currentTarget.textContent
-      //var $idea = $(this).closest('li.collection-item.idea')
-      //var $id = $(this).closest('li').attr('data-id')
-      //var ideaParams = {
-        //idea: {
-          //title: $title
-        //}
-      //}
-
+    event.preventDefault();
       $.ajax({
         type: 'PUT',
         url: '/api/v1/ideas/' + $id + '.json',
-        data: ideaParams,
+        data: params,
         success: function(idea){
-          $(event.target).blur();
-          updateTitle($idea, idea.title);
+          renderIdea(idea);
         }
       })
     }
   })
 }
+

--- a/app/assets/javascripts/update.js
+++ b/app/assets/javascripts/update.js
@@ -1,0 +1,34 @@
+function editIdeaListener(){
+
+  $('#recent-ideas').delegate('.header-description', 'keyup', function(){
+    alert("fdsa")
+  });
+}
+
+function editTitle(){
+  $('.header-description').keydown(function(event){
+    debugger
+    if(event.keyCode == 13){
+
+
+      //var $title = event.currentTarget.textContent
+      //var $idea = $(this).closest('li.collection-item.idea')
+      //var $id = $(this).closest('li').attr('data-id')
+      //var ideaParams = {
+        //idea: {
+          //title: $title
+        //}
+      //}
+
+      $.ajax({
+        type: 'PUT',
+        url: '/api/v1/ideas/' + $id + '.json',
+        data: ideaParams,
+        success: function(idea){
+          $(event.target).blur();
+          updateTitle($idea, idea.title);
+        }
+      })
+    }
+  })
+}

--- a/app/assets/javascripts/update.js
+++ b/app/assets/javascripts/update.js
@@ -1,12 +1,39 @@
 function editIdeaListener(){
   editTitle();
+  editBody();
 }
 
 function editTitle(){
-  $('#recent-ideas').delegate('#idea', 'keydown', function(event){
+  $('#recent-ideas').delegate('#ideaTitle', 'keydown', function(event){
     if(event.which == 13 || event.keyCode == 13){
       var $title = event.currentTarget.textContent
       var $body  = $(this).siblings('.body.description')[0].innerHTML
+      var $id    = $(this).closest('.idea').attr('data-id')
+      var params = {
+        idea: {
+          title: $title,
+          body: $body
+        }
+      }
+
+    event.preventDefault();
+      $.ajax({
+        type: 'PUT',
+        url: '/api/v1/ideas/' + $id + '.json',
+        data: params,
+        success: function(idea){
+          renderIdea(idea);
+        }
+      })
+    }
+  })
+}
+
+function editBody(){
+  $('#recent-ideas').delegate('#ideaBody', 'keydown', function(event){
+    if(event.which == 13 || event.keyCode == 13){
+      var $title = event.currentTarget.textContent
+      var $body  = this.textContent;
       var $id    = $(this).closest('.idea').attr('data-id')
       var params = {
         idea: {

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::IdeasController < ApplicationController
   def update
     idea = Idea.find_by(id: params[:id])
     if idea.update(idea_params)
-      respond_with nil, location: [:api, :v1, idea]
+      respond_with idea, json: idea, location: [:api, :v1, idea]
     end
   end
 


### PR DESCRIPTION
@rrgayhart looks like this is working.

Currently this seems to have some issues with the user pressing enter to to submit a `PUT` request and update the idea. When the user performs this action, the focus stays on the form and the request is sent. Functionally, this works, but it is a bit confusing for the user. Is there a way to remove the focus from the `contenteditable` elements on submit?
